### PR TITLE
add cabal.project instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,15 @@ Edit the [`Main.hs`](examples/playground/Main.hs) file and run the chreography a
 cabal run playground <location>
 ```
 
+If you want to depend on HasChor in your own package, add this to your `cabal.project`.
+
+``` cabal-config
+source-repository-package
+    type: git
+    location: https://github.com/gshen42/HasChor.git
+    branch: main
+```
+
 ## Notes for artifact evaluation
 
 ### Step 1: Obtaining and building the artifact


### PR DESCRIPTION
Cabal lets you depend on git repositories as if they were on Hackage themselves, letting people use the library without cloning it. I added instructions on how to do so to the readme.