### PR TITLE
fix EPP of sending a value to oneself

### DIFF
--- a/src/Choreography/Choreo.hs
+++ b/src/Choreography/Choreo.hs
@@ -6,6 +6,7 @@ module Choreography.Choreo where
 
 import Choreography.Location
 import Choreography.Network
+import Control.Monad (when)
 import Control.Monad.Freer
 import Data.List
 import Data.Proxy
@@ -58,9 +59,10 @@ epp c l' = interpFreer handler c
       | toLocTm l == l' = wrap <$> run (m unwrap)
       | otherwise       = return Empty
     handler (Comm s a r)
-      | toLocTm s == l' = send (unwrap a) (toLocTm r) >> return Empty
-      | toLocTm r == l' = wrap <$> recv (toLocTm s)
-      | otherwise       = return Empty
+      = do when (toLocTm s == l') $ send (unwrap a) (toLocTm r)
+           if toLocTm r == l' 
+             then wrap <$> recv (toLocTm s)
+             else return Empty
     handler (Cond l a c)
       | toLocTm l == l' = broadcast (unwrap a) >> epp (c (unwrap a)) l'
       | otherwise       = recv (toLocTm l) >>= \x -> epp (c x) l'


### PR DESCRIPTION
This is a pretty tiny fix; as currently written Endpoint Projection of an `(A, x) ~> A` operation will cause `A` to "own" (and subsequently `unwrap`) an `Empty`.

Instead of this fix, one might consider forbidding self-sends altogether, but there's no particular reason why they should be illegal. One might also consider handling them specially as no-ops, but we can imagine cases where the network `send` and `recv` get assigned specialized side-effects that shouldn't be skipped. 

The repo doesn't have any unit tests. I've done the bare minimum of running one of the example programs to make sure I didn't break anything. If there's any book-keeping that should accompany a patch like this; I haven't done it.
