### PR TITLE
Fix import by hiding Host

### DIFF
--- a/src/Choreography/Network/Http.hs
+++ b/src/Choreography/Network/Http.hs
@@ -12,7 +12,7 @@ import Data.Proxy (Proxy(..))
 import Data.HashMap.Strict (HashMap, (!))
 import Data.HashMap.Strict qualified as HashMap
 import Network.HTTP.Client (Manager, defaultManagerSettings, newManager)
-import Servant.API
+import Servant.API hiding (Host)
 import Servant.Client (ClientM, client, runClientM, BaseUrl(..), mkClientEnv, Scheme(..))
 import Servant.Server (Handler, Server, serve)
 import Control.Concurrent


### PR DESCRIPTION
In servant `Servant.API` we have

```
module Servant.API (
  (...)
  -- | Matching the @Host@ header.
  module Servant.API.Host,
  (...)
  import           Servant.API.Host (Host)
```

which gives

```
src/Choreography/Network/Http.hs:42:27: error:
    Ambiguous occurrence ‘Host’
    It could refer to
       either ‘Servant.API.Host’,
              imported from ‘Servant.API’ at src/Choreography/Network/Http.hs:15:1-18
              (and originally defined in ‘Servant.API.Host’)
           or ‘Choreography.Network.Http.Host’,
              defined at src/Choreography/Network/Http.hs:37:1
   |
42 | mkHttpConfig :: [(LocTm, (Host, Port))] -> HttpConfig
   |                           ^^^^

src/Choreography/Network/Http.hs:45:11: error:
    Ambiguous occurrence ‘Host’
    It could refer to
       either ‘Servant.API.Host’,
              imported from ‘Servant.API’ at src/Choreography/Network/Http.hs:15:1-18
              (and originally defined in ‘Servant.API.Host’)
           or ‘Choreography.Network.Http.Host’,
              defined at src/Choreography/Network/Http.hs:37:1
   |
45 |     f :: (Host, Port) -> BaseUrl
   |           ^^^^
```

This commit fixes this